### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node ."

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 ![Paste Logo](https://paste.zyrouge.gq/assets/logo.png)
 
 Source Code of [Paste](https://paste.zyrouge.gq)
+
+##### Hosting your own instance
+
+[![Run on Repl.it](https://repl.it/badge/github/zyrouge/paste)](https://repl.it/github/zyrouge/paste)
+
+* Clone this repo
+* Install Modules using `npm install`
+* Run using `node .`


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).